### PR TITLE
Update theme fonts and clean index

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,6 @@
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/tailwind.css"> 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/src/components/common/ErrorBoundary.js
+++ b/src/components/common/ErrorBoundary.js
@@ -140,7 +140,7 @@ class ErrorBoundary extends Component {
                 Error Details:
               </Typography>
               
-              <Typography variant="body2" component="div" sx={{ mb: 2, fontFamily: 'monospace', fontSize: '0.85rem' }}>
+              <Typography variant="body2" component="div" sx={{ mb: 2, fontFamily: theme.typography.fontFamily, fontSize: '0.85rem' }}>
                 <Box component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
                   {error?.toString() || 'Unknown error'}
                 </Box>
@@ -152,7 +152,7 @@ class ErrorBoundary extends Component {
                 Component Stack:
               </Typography>
               
-              <Typography variant="body2" component="div" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+              <Typography variant="body2" component="div" sx={{ fontFamily: theme.typography.fontFamily, fontSize: '0.75rem' }}>
                 <Box component="pre" sx={{ 
                   whiteSpace: 'pre-wrap', 
                   wordBreak: 'break-word',

--- a/src/components/common/GlobalErrorHandler.js
+++ b/src/components/common/GlobalErrorHandler.js
@@ -154,7 +154,7 @@ const GlobalErrorHandler = () => {
                 Error Message:
               </Typography>
               
-              <Typography variant="body2" component="div" sx={{ mb: 2, fontFamily: 'monospace' }}>
+              <Typography variant="body2" component="div" sx={{ mb: 2, fontFamily: theme.typography.fontFamily }}>
                 <Box component="pre" sx={{ 
                   whiteSpace: 'pre-wrap', 
                   wordBreak: 'break-word',
@@ -172,7 +172,7 @@ const GlobalErrorHandler = () => {
                     Stack Trace:
                   </Typography>
                   
-                  <Typography variant="body2" component="div" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                  <Typography variant="body2" component="div" sx={{ fontFamily: theme.typography.fontFamily, fontSize: '0.75rem' }}>
                     <Box component="pre" sx={{ 
                       whiteSpace: 'pre-wrap', 
                       wordBreak: 'break-word',

--- a/src/components/common/ImageErrorHandler.js
+++ b/src/components/common/ImageErrorHandler.js
@@ -192,7 +192,7 @@ const ImageErrorHandler = ({
             variant="caption"
             component="pre"
             sx={{
-              fontFamily: 'monospace',
+              fontFamily: theme.typography.fontFamily,
               fontSize: '0.7rem',
               wordBreak: 'break-all',
               whiteSpace: 'pre-wrap',

--- a/src/theme.js
+++ b/src/theme.js
@@ -98,8 +98,8 @@ const createAppTheme = (mode = 'dark') => {
     },
     typography: {
       fontFamily: [
-        'Inter',
-        'Roboto',
+        'Montserrat',
+        'IBM Plex Mono',
         '-apple-system',
         'BlinkMacSystemFont',
         'Arial',

--- a/src/theme/typography.js
+++ b/src/theme/typography.js
@@ -8,8 +8,8 @@
 // Define and export typography settings directly (do not import tokens here)
 const typography = {
   fontFamily: [
-    'Inter',
-    'Roboto',
+    'Montserrat',
+    'IBM Plex Mono',
     '-apple-system',
     'BlinkMacSystemFont',
     'Arial',


### PR DESCRIPTION
## Summary
- remove unused TailwindCSS link
- align theme fonts with Montserrat & IBM Plex Mono
- enforce theme font usage in error components

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a970a097883209a647eb5b0db1837