### PR TITLE
Ensure project parser used in modal

### DIFF
--- a/src/components/work/ProjectModal.js
+++ b/src/components/work/ProjectModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useRef, useState } from 'react';
+import React, { useEffect, useCallback, useRef, useState, useMemo } from 'react';
 import { Modal, Box, IconButton, useTheme, CircularProgress } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
@@ -7,6 +7,7 @@ import Tooltip from '@mui/material/Tooltip';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import ProjectFullContent from './ProjectFullContent';
 import { useSwipeable } from 'react-swipeable';
+import parseProjectContent from '../../utils/projectContentParser';
 import SwipeRightAltIcon from '@mui/icons-material/SwipeRightAlt';
 import SwipeLeftAltIcon from '@mui/icons-material/SwipeLeftAlt';
 
@@ -31,6 +32,7 @@ const ProjectModal = ({
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
   const contentRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
+  const parsedProject = useMemo(() => parseProjectContent(project), [project]);
 
   // Enhanced swipe handlers with better sensitivity settings
   const swipeHandlers = useSwipeable({
@@ -481,8 +483,8 @@ const ProjectModal = ({
             }
           }}
         >
-          <ProjectFullContent 
-            project={project} 
+          <ProjectFullContent
+            project={parsedProject}
             isLoading={isLoading}
             setIsLoading={setIsLoading}
           />

--- a/src/components/work/Work.js
+++ b/src/components/work/Work.js
@@ -3,6 +3,7 @@ import { Box, Typography, useTheme, CircularProgress, Button } from '@mui/materi
 import { motion } from 'framer-motion';
 import ProjectGrid from './ProjectGrid';
 import ProjectModal from './ProjectModal';
+import parseProjectContent from '../../utils/projectContentParser';
 import { getProjects } from './data/index'; // UPDATED: Import from the correct location
 import ErrorBoundary from '../common/ErrorBoundary';
 import useDataLoader from '../../hooks/useDataLoader';
@@ -202,7 +203,7 @@ const Work = () => {
         <ProjectModal
           open={isModalOpen}
           onClose={handleCloseModal}
-          project={selectedProjectIndex !== null ? projects[selectedProjectIndex] : null}
+          project={selectedProjectIndex !== null ? parseProjectContent(projects[selectedProjectIndex]) : null}
           onNextProject={handleNextProject}
           onPreviousProject={handlePrevProject}
         />


### PR DESCRIPTION
## Summary
- parse project data with `parseProjectContent` before rendering the modal
- feed parsed data to `ProjectFullContent`

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688a9c82f9ec8320938407fe5c9da635