### PR TITLE
refactor: use react-pdf for PDF viewer

### DIFF
--- a/src/components/common/PDFViewer.js
+++ b/src/components/common/PDFViewer.js
@@ -1,291 +1,109 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Box, CircularProgress, Typography, Button, useMediaQuery, Stack } from '@mui/material';
+import React, { useState, useRef, useEffect } from 'react';
+import { Box, Button, CircularProgress, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-// Remove unused icons but keep them commented for future reference
-// import ZoomInIcon from '@mui/icons-material/ZoomIn';
-// import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import { Document, Page, pdfjs } from 'react-pdf';
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+import 'react-pdf/dist/esm/Page/TextLayer.css';
 
-/**
- * PDFViewer Component
- * 
- * Displays a PDF document in an iframe with improved handling of both
- * imported PDF files and URL references. Mobile version optimized for
- * better user experience with direct viewing options.
- */
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+
 const PDFViewer = ({ url, title, onCloseFocusRef }) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const blobUrlRef = useRef(null);
+  const [numPages, setNumPages] = useState(null);
+  const [blobUrl, setBlobUrl] = useState(null);
   const downloadBtnRef = useRef(null);
-  
-  // Generate a proper URL for the PDF, whether it's an imported file or string path
+
   const pdfUrl = React.useMemo(() => {
     if (typeof url === 'object') {
-      const blobUrl = URL.createObjectURL(new Blob([url], { type: 'application/pdf' }));
-      blobUrlRef.current = blobUrl;
-      return blobUrl;
+      const blob = URL.createObjectURL(new Blob([url], { type: 'application/pdf' }));
+      setBlobUrl(blob);
+      return blob;
     }
     return url;
   }, [url]);
 
-  // Clean up Blob URL on unmount
-  useEffect(() => {
-    return () => {
-      if (blobUrlRef.current) {
-        URL.revokeObjectURL(blobUrlRef.current);
-        blobUrlRef.current = null;
-      }
-    };
-  }, [pdfUrl]);
+  useEffect(() => () => {
+    if (blobUrl) URL.revokeObjectURL(blobUrl);
+  }, [blobUrl]);
 
-  // Focus management: expose download button ref to parent for focus restoration
   useEffect(() => {
     if (onCloseFocusRef && downloadBtnRef.current) {
       onCloseFocusRef.current = downloadBtnRef.current;
     }
   }, [onCloseFocusRef]);
 
-  // Handle iframe load completion
-  const handleLoad = () => {
-    console.log('PDF loaded successfully');
-    setIsLoading(false);
-  };
-  
-  // Handle iframe load error
-  const handleError = () => {
-    console.error('Failed to load PDF:', pdfUrl);
-    setIsLoading(false);
-    setHasError(true);
-  };
-  
-  // Extract filename for download button
   const getFileName = () => {
     try {
       if (typeof url === 'string') {
-        const pathParts = url.split('/');
-        return pathParts[pathParts.length - 1];
-      } else {
-        return title ? `${title.replace(/\s+/g, '_')}.pdf` : 'document.pdf';
+        const parts = url.split('/');
+        return parts[parts.length - 1];
       }
-    } catch (e) {
+      return title ? `${title.replace(/\s+/g, '_')}.pdf` : 'document.pdf';
+    } catch {
       return 'document.pdf';
     }
   };
-  
-  // For mobile, provide improved PDF viewing options
-  if (isMobile) {
-    return (
-      <Box 
-        sx={{ 
-          width: '100%', 
-          height: '100%', 
-          display: 'flex', 
-          flexDirection: 'column',
-          bgcolor: theme.palette.background.paper,
-          overflow: 'hidden'
-        }}
-      >
-        {/* PDF Container - Full-screen iOS-friendly PDF viewer */}
-        <Box 
-          sx={{
-            width: '100%', 
-            flex: 1,
-            overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column',
-            '-webkit-overflow-scrolling': 'touch', // Improve iOS scrolling
-          }}
-        >
-          {isLoading && (
-            <Box 
-              sx={{ 
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                p: 4,
-                flex: 1
-              }}
-            >
-              <CircularProgress size={40} />
-              <Typography variant="body2" sx={{ mt: 2 }}>
-                Loading PDF...
-              </Typography>
+
+  const onDocumentLoadSuccess = ({ numPages: nextNumPages }) => {
+    setNumPages(nextNumPages);
+  };
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: theme.palette.background.paper,
+      }}
+    >
+      <Box sx={{ flex: 1, overflow: 'auto', p: isMobile ? 1 : 2 }}>
+        <Document
+          file={pdfUrl}
+          loading={
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+              <CircularProgress />
             </Box>
-          )}
-
-          {/* Direct PDF iframe with enhanced mobile settings */}
-          <Box 
-            component="iframe"
-            src={pdfUrl}
-            title={title || "PDF Document"}
-            onLoad={handleLoad}
-            onError={handleError}
-            sx={{
-              width: '100%',
-              flex: 1,
-              border: 'none',
-              display: isLoading ? 'none' : 'block',
-              overflow: 'auto',
-              '-webkit-overflow-scrolling': 'touch', // iOS scroll momentum
-            }}
-          />
-        </Box>
-        
-        {/* Bottom action bar with viewing options */}
-        <Box 
-          sx={{ 
-            p: 2,
-            borderTop: `1px solid ${theme.palette.divider}`,
-            display: 'flex',
-            justifyContent: 'space-between',
-          }}
+          }
+          onLoadSuccess={onDocumentLoadSuccess}
         >
-          <Button
-            variant="outlined"
-            startIcon={<FileDownloadIcon />}
-            href={pdfUrl}
-            download={getFileName()}
-            ref={downloadBtnRef}
-          >
-            Download
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            startIcon={<OpenInNewIcon />}
-            href={pdfUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Open in New Tab
-          </Button>
-        </Box>
+          {Array.from(new Array(numPages), (el, index) => (
+            <Page
+              key={`page_${index + 1}`}
+              pageNumber={index + 1}
+              width={isMobile ? undefined : 600}
+            />
+          ))}
+        </Document>
       </Box>
-    );
-  }
-
-  if (hasError) {
-    return (
-      <Box 
-        sx={{ 
-          width: '100%',
-          height: '70vh',
-          display: 'flex', 
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          bgcolor: theme.palette.background.paper,
-          borderRadius: theme.shape.borderRadius,
-          p: 4,
-          textAlign: 'center',
+      <Box
+        sx={{
+          p: 2,
+          borderTop: `1px solid ${theme.palette.divider}`,
+          display: 'flex',
+          justifyContent: 'space-between',
         }}
       >
-        <Typography 
-          variant="h6" 
-          color="error"
-          sx={{ mb: 2 }}
+        <Button
+          variant="outlined"
+          startIcon={<FileDownloadIcon />}
+          href={pdfUrl}
+          download={getFileName()}
+          ref={downloadBtnRef}
         >
-          Unable to load PDF
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 3 }}>
-          The PDF document could not be loaded. Please try downloading it directly.
-        </Typography>
+          Download
+        </Button>
         <Button
           variant="contained"
-          startIcon={<FileDownloadIcon />}
-          href={pdfUrl}
-          download={getFileName()}
-          target="_blank"
-          rel="noopener noreferrer"
-          ref={downloadBtnRef}
-        >
-          Download PDF
-        </Button>
-      </Box>
-    );
-  }
-  
-  return (
-    <Box sx={{ width: '100%', height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', position: 'relative' }}>
-      {isLoading && (
-        <Box 
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: theme.palette.background.paper,
-            zIndex: 1,
-          }}
-        >
-          <CircularProgress size={60} />
-        </Box>
-      )}
-      <Box 
-        sx={{
-          width: '100%',
-          height: '100%',
-          minHeight: 0,
-          flex: 1,
-          border: 'none',
-          display: 'block',
-          borderRadius: theme.shape.borderRadius,
-          overflow: 'auto',
-          touchAction: 'pan-x pan-y',
-          WebkitOverflowScrolling: 'touch',
-        }}
-      >
-        <Box
-          component="iframe"
-          src={pdfUrl}
-          title={title || "PDF Document"}
-          onLoad={handleLoad}
-          onError={handleError}
-          sx={{
-            width: '100%',
-            height: '100%',
-            minHeight: 0,
-            border: 'none',
-            display: 'block',
-            borderRadius: theme.shape.borderRadius,
-          }}
-        />
-      </Box>
-      <Box sx={{ 
-        display: 'flex', 
-        justifyContent: 'space-between',
-        p: 2,
-        borderTop: `1px solid ${theme.palette.divider}`,
-        bgcolor: theme.palette.background.paper,
-      }}>
-        <Button
-          variant="outlined"
-          startIcon={<FileDownloadIcon />}
-          href={pdfUrl}
-          download={getFileName()}
-          target="_blank"
-          rel="noopener noreferrer"
-          size="small"
-          ref={downloadBtnRef}
-        >
-          Download PDF
-        </Button>
-        <Button
-          variant="outlined"
+          color="primary"
           startIcon={<OpenInNewIcon />}
           href={pdfUrl}
           target="_blank"
           rel="noopener noreferrer"
-          size="small"
         >
           Open in New Tab
         </Button>

--- a/src/components/work/Work.test.js
+++ b/src/components/work/Work.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import useDataLoader from '../../hooks/useDataLoader';
 import Work from './Work';
 import ThemeProvider from '../../context/ThemeContext';
 
-jest.mock('../../hooks/useDataLoader', () => {
-  return jest.fn(() => ({
+jest.mock('../../hooks/useDataLoader');
+
+beforeEach(() => {
+  useDataLoader.mockReturnValue({
     data: [
       {
         id: 'proj1',
@@ -16,8 +19,8 @@ jest.mock('../../hooks/useDataLoader', () => {
     ],
     isLoading: false,
     error: null,
-    reload: jest.fn()
-  }));
+    reload: jest.fn(),
+  });
 });
 
 test('renders project cards from loaded data', () => {

--- a/src/components/work/data/projects/greenWallet.js
+++ b/src/components/work/data/projects/greenWallet.js
@@ -33,7 +33,7 @@ import ConceptOverview6Image from '../../../../assets/images/GreenWallet/concept
 import HighlightReelVideo from '../../../../assets/images/GreenWallet/highlight_reel.mp4';
 import PresentationVideo from '../../../../assets/images/GreenWallet/presentation_video.mp4';
 // Directory name in repo uses lowercase 'w' for Greenwallet
-import presentationPDF from '../../../../assets/information/GreenWallet/GreenWallet_Presentation.pdf';
+import presentationPDF from '../../../../assets/information/Greenwallet/GreenWallet_Presentation.pdf';
 
 // Create a media object to hold all our imported media
 const media = {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+jest.mock('react-pdf', () => ({
+  Document: ({ children }) => <div>{children}</div>,
+  Page: () => <div />,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' }, version: '' },
+}));
+
+window.matchMedia = window.matchMedia || function () {
+  return {
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => {},
+  };
+};
+
+class MockIntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+window.IntersectionObserver = window.IntersectionObserver || MockIntersectionObserver;


### PR DESCRIPTION
## Summary
- replace iframe-based PDFViewer with `react-pdf` Document/Page and download/open controls
- fix GreenWallet presentation PDF path and update Work tests
- add Jest setup mocking `react-pdf` and browser APIs

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892393c9608832091342c759c0cc274