### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/components/work/ProjectLinks.js
+++ b/src/components/work/ProjectLinks.js
@@ -18,6 +18,18 @@ import CodeIcon from '@mui/icons-material/Code';
  * presentations, prototypes, code repositories, etc.
  */
 
+// Returns true if url is on figma.com or subdomains thereof
+function isFigmaDomain(url) {
+  try {
+    // Support relative URLs by providing origin base
+    const parsed = new URL(url, window.location.origin);
+    // Accept figma.com and any subdomain of figma.com
+    return parsed.hostname === 'figma.com' || parsed.hostname.endsWith('.figma.com');
+  } catch {
+    return false;
+  }
+}
+
 // Centralized icon and color logic (migrated from buttonStyles.js)
 export const getLinkIcon = (label) => {
   if (!label) return <OpenInNewIcon />;
@@ -104,7 +116,7 @@ const ProjectLinks = ({ prototype, presentation, links = [], title = "" }) => {
           if (!link.contentType) {
             if (link.url && link.url.endsWith('.pdf')) {
               contentType = 'pdf';
-            } else if (link.url && (link.url.includes('figma.com') || link.url.includes('prototype'))) {
+            } else if (link.url && (isFigmaDomain(link.url) || link.url.includes('prototype'))) {
               contentType = 'iframe';
             }
           }


### PR DESCRIPTION
Potential fix for [https://github.com/YungSeepferd/Portfolio/security/code-scanning/6](https://github.com/YungSeepferd/Portfolio/security/code-scanning/6)

To fix this, we should parse each `link.url` value with the standard JavaScript URL API to extract the hostname (domain), and then check if it exactly matches "figma.com" or an accepted subdomain of it (such as "*.figma.com"). This ensures we only act on canonical trusted domains and not accidental matches elsewhere in the URL. In practical terms, on line 107 of `src/components/work/ProjectLinks.js`, replace the substring check `link.url.includes('figma.com')` with a proper host check. 

We'll need to add a safe way to parse and check the hostname (`new URL(link.url, window.location.origin)` for relative URLs). For our use-case (modal handling), subdomains are acceptable, so we can check `host.endsWith('figma.com')`. We should also be careful to handle parsing errors in case of an invalid URL; falling back gracefully in such scenarios will ensure no runtime crashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
